### PR TITLE
Added support for Resque gem version 1.23.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,33 @@
 PATH
   remote: .
   specs:
-    resque-multi-job-forks (0.3.1)
+    resque-multi-job-forks (0.3.2)
       json
-      resque (~> 1.10.0)
+      resque (~> 1.22)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    json (1.4.6)
-    rack (1.2.1)
+    json (1.7.7)
+    multi_json (1.6.1)
+    rack (1.5.2)
+    rack-protection (1.3.2)
+      rack
     rake (0.8.7)
-    redis (2.1.1)
-    redis-namespace (0.8.0)
-      redis (< 3.0.0)
-    resque (1.10.0)
-      json (~> 1.4.6)
-      redis-namespace (~> 0.8.0)
+    redis (3.0.2)
+    redis-namespace (1.2.1)
+      redis (~> 3.0.0)
+    resque (1.23.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.0)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
-    sinatra (1.1.0)
-      rack (~> 1.1)
-      tilt (~> 1.1)
-    tilt (1.1)
-    vegas (0.1.8)
+    sinatra (1.3.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.3)
+      tilt (~> 1.3, >= 1.3.3)
+    tilt (1.3.3)
+    vegas (0.1.11)
       rack (>= 1.0.0)
 
 PLATFORMS
@@ -31,7 +35,5 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
-  json
   rake
-  resque (~> 1.10.0)
   resque-multi-job-forks!

--- a/resque-multi-job-forks.gemspec
+++ b/resque-multi-job-forks.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.summary     = "Have your resque workers process more that one job"
   s.description = "When your resque jobs are frequent and fast, the overhead of forking and running your after_fork might get too big."
 
-  s.add_runtime_dependency("resque", "~> 1.22.0")
+  s.add_runtime_dependency("resque", "~> 1.22")
   s.add_runtime_dependency("json")
 
   s.add_development_dependency("rake")

--- a/test/test_resque-multi-job-forks.rb
+++ b/test/test_resque-multi-job-forks.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require File.join(File.expand_path(File.dirname(__FILE__)), '/helper')
 
 class TestResqueMultiJobForks < Test::Unit::TestCase
   def setup


### PR DESCRIPTION
The current version of the gem requires version 1.22.0 of the Resque gem, however the current stable version of Resque is 1.23.0.  This updates the dependency to "~> 1.22", allowing version 1.23.0.  I updated the tests to ensure it works with both v1.22 and v1.23.
