### PR TITLE
Handle QUIT signal

### DIFF
--- a/lib/resque-multi-job-forks.rb
+++ b/lib/resque-multi-job-forks.rb
@@ -17,7 +17,7 @@ module Resque
       alias_method :perform, :perform_with_multi_job_forks
 
       def shutdown_with_multi_job_forks
-        release_fork if fork_hijacked? && fork_job_limit_reached?
+        release_fork if fork_hijacked? && (fork_job_limit_reached? || @shutdown)
         shutdown_without_multi_job_forks
       end
       alias_method :shutdown_without_multi_job_forks, :shutdown?


### PR DESCRIPTION
After required this library, I found that resque worker doesn't handle QUIT signal properly.

https://github.com/defunkt/resque/blob/1-x-stable/README.markdown#signals

You can compare the behaviour with sending QUIT to a process w/ resque-multi-job-forks and w/o resque-multi-job-forks.

The child worker needs to check `@shutdown` and release_fork when it is true.
