### PR TITLE
Limit to Resque 1.2[4-6] since 1.23 and 1.27 are incompatible

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     resque-multi-job-forks (0.4.3)
       json
-      resque (~> 1.22)
+      resque (>= 1.24, < 1.27)
 
 GEM
   remote: http://rubygems.org/
@@ -11,24 +11,24 @@ GEM
     json (2.1.0)
     mono_logger (1.1.0)
     multi_json (1.13.1)
-    mustermann (1.0.1)
+    mustermann (1.0.2)
     power_assert (1.1.1)
     rack (2.0.4)
-    rack-protection (2.0.0)
+    rack-protection (2.0.1)
       rack
     redis (4.0.1)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
-    resque (1.27.4)
+    resque (1.26.0)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
       redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
-    sinatra (2.0.0)
+    sinatra (2.0.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.0)
+      rack-protection (= 2.0.1)
       tilt (~> 2.0)
     test-unit (3.2.7)
       power_assert

--- a/resque-multi-job-forks.gemspec
+++ b/resque-multi-job-forks.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.summary     = "Have your resque workers process more that one job"
   s.description = "When your resque jobs are frequent and fast, the overhead of forking and running your after_fork might get too big."
 
-  s.add_runtime_dependency("resque", "~> 1.22")
+  s.add_runtime_dependency("resque", ">= 1.24", "< 1.27")
   s.add_runtime_dependency("json")
 
   s.add_development_dependency("test-unit")


### PR DESCRIPTION
* We patch the reconnect method which was released in 1.24
* We set @cant_fork to prevent forking, which was removed in 1.27