### PR TITLE
Register the TSTP signal handler before invoking the first job

### DIFF
--- a/lib/resque-multi-job-forks.rb
+++ b/lib/resque-multi-job-forks.rb
@@ -16,8 +16,8 @@ module Resque
 
     if multi_jobs_per_fork? && !method_defined?(:shutdown_without_multi_job_forks)
       def perform_with_multi_job_forks(job = nil)
-        perform_without_multi_job_forks(job)
         hijack_fork unless fork_hijacked?
+        perform_without_multi_job_forks(job)
         @jobs_processed += 1
       end
       alias_method :perform_without_multi_job_forks, :perform


### PR DESCRIPTION
Fixes an issue where if the first job is a long running one, and you issue a SIGQUIT to the resque-pool-manager for a gracefully shutdown, you'll end up with your worker in a stopped state (T) as the trap() hasn't been set. eg:

```
root       941 85.5  0.7 392348 211224 ?       Sl+  18:34   0:08  \_ resque-pool-master[7bba15]: managing [949]
root       949  3.0  0.7 459940 200488 ?       Sl   18:34   0:00      \_ resque-1.26.0: Forked 957 at 1527705279
root       957  0.0  0.7 459940 199704 ?       Sl   18:34   0:00          \_ resque-1.26.0: Processing demo since 1527705279 [LongJob]

$ kill -QUIT 941

root       941 47.5  0.7 392348 211224 ?       Sl+  18:34   0:08  \_ resque-pool-master[7bba15]: managing [949]
root       949  0.3  0.7 459940 200488 ?       Sl   18:34   0:00      \_ resque-1.26.0: Forked 957 at 1527705279
root       957  0.0  0.7 459940 199704 ?       Tl   18:34   0:00          \_ resque-1.26.0: Processing demo since 1527705279 [LongJob]
```
Oops! It stays wedged like this indefinitely.