### PR TITLE
Fix tests for resque v1.26.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
     rack (2.0.6)
     rack-protection (2.0.5)
       rack
+    rake (12.3.2)
     redis (4.1.0)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
@@ -41,6 +42,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
+  rake
   resque-multi-job-forks!
   test-unit
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    resque-multi-job-forks (0.4.3)
+    resque-multi-job-forks (0.4.4)
       json
-      resque (>= 1.24, < 1.27)
+      resque (~> 1.26.0)
 
 GEM
   remote: http://rubygems.org/
@@ -11,12 +11,12 @@ GEM
     json (2.1.0)
     mono_logger (1.1.0)
     multi_json (1.13.1)
-    mustermann (1.0.2)
+    mustermann (1.0.3)
     power_assert (1.1.1)
-    rack (2.0.4)
-    rack-protection (2.0.1)
+    rack (2.0.6)
+    rack-protection (2.0.5)
       rack
-    redis (4.0.1)
+    redis (4.1.0)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
     resque (1.26.0)
@@ -25,14 +25,14 @@ GEM
       redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
-    sinatra (2.0.1)
+    sinatra (2.0.5)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.1)
+      rack-protection (= 2.0.5)
       tilt (~> 2.0)
     test-unit (3.2.7)
       power_assert
-    tilt (2.0.8)
+    tilt (2.0.9)
     vegas (0.1.11)
       rack (>= 1.0.0)
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,8 @@ require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
   test.pattern = 'test/**/test_*.rb'
-  test.verbose = true
+  test.verbose = ENV["VERBOSE"] == "true"
+  test.warning = ENV["VERBOSE"] == "true"
 end
 
 task :default => :test

--- a/resque-multi-job-forks.gemspec
+++ b/resque-multi-job-forks.gemspec
@@ -10,7 +10,8 @@ Gem::Specification.new do |s|
   s.summary     = "Have your resque workers process more that one job"
   s.description = "When your resque jobs are frequent and fast, the overhead of forking and running your after_fork might get too big."
 
-  s.add_runtime_dependency("resque", ">= 1.24", "< 1.27")
+  # Depends on minor version, due to monkeypatches Resque::Worker internals.
+  s.add_runtime_dependency("resque", "~> 1.26.0")
   s.add_runtime_dependency("json")
 
   s.add_development_dependency("test-unit")

--- a/resque-multi-job-forks.gemspec
+++ b/resque-multi-job-forks.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("test-unit")
   s.add_development_dependency("bundler")
+  s.add_development_dependency("rake")
 
   s.files         = Dir["lib/**/*"]
   s.test_files    = Dir["test/**/*"]

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -19,44 +19,20 @@ Resque.redis = $redis
 # set `VERBOSE=true` when running the tests to view resques log output.
 module Resque
   class Worker
+
     def log(msg)
       puts "*** #{msg}" unless ENV['VERBOSE'].nil?
     end
     alias_method :log!, :log
 
-    # Processes a given job in the child.
-    def perform_without_multi_job_forks(job)
-      begin
-        # 'will_fork?' returns false in test mode, but since we need to test
-        # if the :after_fork hook runs, we ignore 'will_fork?' here.
-        run_hook :after_fork, job # if will_fork?
-        job.perform
-      rescue Object => e
-        log "#{job.inspect} failed: #{e.inspect}"
-        begin
-          job.fail(e)
-        rescue Object => e
-          log "Received exception when reporting failure: #{e.inspect}"
-        end
-        failed!
-      else
-        log "done: #{job.inspect}"
-      ensure
-        yield job if block_given?
-      end
-    end
   end
 end
-
-# stores a record of the job processing sequence.
-# you may wish to reset this in the test `setup` method.
-$SEQUENCE = []
 
 # test job, tracks sequence.
 class SequenceJob
   @queue = :jobs
   def self.perform(i)
-    $SEQUENCE << "work_#{i}".to_sym
+    $SEQ_WRITER.print "work_#{i}\n"
     sleep(2)
   end
 end
@@ -64,20 +40,20 @@ end
 class QuickSequenceJob
   @queue = :jobs
   def self.perform(i)
-    $SEQUENCE << "work_#{i}".to_sym
+    $SEQ_WRITER.print "work_#{i}\n"
   end
 end
 
 
 # test hooks, tracks sequence.
 Resque.after_fork do
-  $SEQUENCE << :after_fork
+  $SEQ_WRITER.print "after_fork\n"
 end
 
 Resque.before_fork do
-  $SEQUENCE << :before_fork
+  $SEQ_WRITER.print "before_fork\n"
 end
 
 Resque.before_child_exit do |worker|
-  $SEQUENCE << "before_child_exit_#{worker.jobs_processed}".to_sym
+  $SEQ_WRITER.print "before_child_exit_#{worker.jobs_processed}\n"
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,8 +12,8 @@ require 'resque-multi-job-forks'
 require 'timeout'
 
 # setup redis & resque.
-redis = Redis.new(:db => 1)
-Resque.redis = redis
+$redis = Redis.new(:db => 1)
+Resque.redis = $redis
 
 # adds simple STDOUT logging to test workers.
 # set `VERBOSE=true` when running the tests to view resques log output.

--- a/test/test_resque-multi-job-forks.rb
+++ b/test/test_resque-multi-job-forks.rb
@@ -3,7 +3,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), '/helper')
 class TestResqueMultiJobForks < Test::Unit::TestCase
   def setup
     $SEQUENCE = []
-    Resque.redis.flushdb
+    $redis.flushdb
     @worker = Resque::Worker.new(:jobs)
   end
 

--- a/test/test_rss_reader.rb
+++ b/test/test_rss_reader.rb
@@ -7,17 +7,20 @@ class TestRssReader < Test::Unit::TestCase
     @object.extend Resque::Plugins::MultiJobForks::RssReader
   end
 
+  # support before/after ruby 2.4 without deprecation notice
+  IntegerClass = 1.class
+
   def test_current_process_rss
     rss = @object.rss
     # not a very strict test, but have you ever seen a ruby process < 1Mb?
     # the "real" test is manual verification via top/ps/htop
-    assert_equal Fixnum, rss.class
+    assert_equal IntegerClass, rss.class
     assert @object.rss > 1000
   end
 
   def test_rss_other_processes
     rss = @object.rss(1) # init is guaranteed to exist
-    assert_equal Fixnum, rss.class
+    assert_equal IntegerClass, rss.class
     assert @object.rss > 1000
   end
 


### PR DESCRIPTION
This has been tested with all currently supported versions of ruby (2.3, 2.4, 2.5, and 2.6).

Major changes (as documented in 9815ab6):
* Tests use normal fork and communicate with test runner via IO.pipe.
* Tests uses a zero interval to exit ASAP without timeout when done.
* Children need to `exit!` to avoid running test/unit at_exit hooks.
* Gemspec depends on a specific minor version of resque.

We must depend on ~> v1.26.0, because these methods are considered
internal, are not a stable API, and can change with every version. I.e.
as written, the tests do not pass with v1.25.0 nor with v1.27.0. Until
Resque::Worker has a stable API we can target, this gem will need to be
tested with each minor release.