### PR TITLE
Mark as compatible with resque v2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
     rack (2.0.6)
     rack-protection (2.0.5)
       rack
+    rake (12.3.2)
     redis (4.1.0)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
@@ -41,6 +42,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
+  rake
   resque-multi-job-forks!
   test-unit
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     resque-multi-job-forks (0.4.4)
       json
-      resque (~> 1.27.0)
+      resque (>= 1.27.0, < 2.1)
 
 GEM
   remote: http://rubygems.org/
@@ -20,10 +20,10 @@ GEM
     redis (4.1.0)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
-    resque (1.27.4)
+    resque (2.0.0)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
-      redis-namespace (~> 1.3)
+      redis-namespace (~> 1.6)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
     sinatra (2.0.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    resque-multi-job-forks (0.4.3)
+    resque-multi-job-forks (0.4.4)
       json
-      resque (>= 1.24, < 1.27)
+      resque (~> 1.26.0)
 
 GEM
   remote: http://rubygems.org/
@@ -11,12 +11,12 @@ GEM
     json (2.1.0)
     mono_logger (1.1.0)
     multi_json (1.13.1)
-    mustermann (1.0.2)
+    mustermann (1.0.3)
     power_assert (1.1.1)
-    rack (2.0.4)
-    rack-protection (2.0.1)
+    rack (2.0.6)
+    rack-protection (2.0.5)
       rack
-    redis (4.0.1)
+    redis (4.1.0)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
     resque (1.26.0)
@@ -25,14 +25,14 @@ GEM
       redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
-    sinatra (2.0.1)
+    sinatra (2.0.5)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.1)
+      rack-protection (= 2.0.5)
       tilt (~> 2.0)
     test-unit (3.2.7)
       power_assert
-    tilt (2.0.8)
+    tilt (2.0.9)
     vegas (0.1.11)
       rack (>= 1.0.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     resque-multi-job-forks (0.4.4)
       json
-      resque (~> 1.26.0)
+      resque (~> 1.27.0)
 
 GEM
   remote: http://rubygems.org/
@@ -20,7 +20,7 @@ GEM
     redis (4.1.0)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
-    resque (1.26.0)
+    resque (1.27.4)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
       redis-namespace (~> 1.3)

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,8 @@ require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
   test.pattern = 'test/**/test_*.rb'
-  test.verbose = true
+  test.verbose = ENV["VERBOSE"] == "true"
+  test.warning = ENV["VERBOSE"] == "true"
 end
 
 task :default => :test

--- a/lib/resque-multi-job-forks.rb
+++ b/lib/resque-multi-job-forks.rb
@@ -24,6 +24,7 @@ module Resque
       alias_method :work, :work_with_multi_job_forks
 
       def perform_with_multi_job_forks(job = nil)
+        trap('QUIT') { shutdown } unless fork_hijacked?
         perform_without_multi_job_forks(job)
         hijack_fork unless fork_hijacked?
         @jobs_processed += 1

--- a/resque-multi-job-forks.gemspec
+++ b/resque-multi-job-forks.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description = "When your resque jobs are frequent and fast, the overhead of forking and running your after_fork might get too big."
 
   # Depends on minor version, due to monkeypatches Resque::Worker internals.
-  s.add_runtime_dependency("resque", "~> 1.26.0")
+  s.add_runtime_dependency("resque", "~> 1.27.0")
   s.add_runtime_dependency("json")
 
   s.add_development_dependency("test-unit")

--- a/resque-multi-job-forks.gemspec
+++ b/resque-multi-job-forks.gemspec
@@ -10,7 +10,8 @@ Gem::Specification.new do |s|
   s.summary     = "Have your resque workers process more that one job"
   s.description = "When your resque jobs are frequent and fast, the overhead of forking and running your after_fork might get too big."
 
-  s.add_runtime_dependency("resque", ">= 1.24", "< 1.27")
+  # Depends on minor version, due to monkeypatches Resque::Worker internals.
+  s.add_runtime_dependency("resque", "~> 1.26.0")
   s.add_runtime_dependency("json")
 
   s.add_development_dependency("test-unit")

--- a/resque-multi-job-forks.gemspec
+++ b/resque-multi-job-forks.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("test-unit")
   s.add_development_dependency("bundler")
+  s.add_development_dependency("rake")
 
   s.files         = Dir["lib/**/*"]
   s.test_files    = Dir["test/**/*"]

--- a/resque-multi-job-forks.gemspec
+++ b/resque-multi-job-forks.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description = "When your resque jobs are frequent and fast, the overhead of forking and running your after_fork might get too big."
 
   # Depends on minor version, due to monkeypatches Resque::Worker internals.
-  s.add_runtime_dependency("resque", "~> 1.27.0")
+  s.add_runtime_dependency("resque", ">= 1.27.0", "< 2.1")
   s.add_runtime_dependency("json")
 
   s.add_development_dependency("test-unit")

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -32,8 +32,8 @@ end
 class SequenceJob
   @queue = :jobs
   def self.perform(i)
-    $SEQ_WRITER.print "work_#{i}\n"
     sleep(2)
+    $SEQ_WRITER.print "work_#{i}\n"
   end
 end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -19,44 +19,20 @@ Resque.redis = $redis
 # set `VERBOSE=true` when running the tests to view resques log output.
 module Resque
   class Worker
+
     def log(msg)
       puts "*** #{msg}" unless ENV['VERBOSE'].nil?
     end
     alias_method :log!, :log
 
-    # Processes a given job in the child.
-    def perform_without_multi_job_forks(job)
-      begin
-        # 'will_fork?' returns false in test mode, but since we need to test
-        # if the :after_fork hook runs, we ignore 'will_fork?' here.
-        run_hook :after_fork, job # if will_fork?
-        job.perform
-      rescue Object => e
-        log "#{job.inspect} failed: #{e.inspect}"
-        begin
-          job.fail(e)
-        rescue Object => e
-          log "Received exception when reporting failure: #{e.inspect}"
-        end
-        failed!
-      else
-        log "done: #{job.inspect}"
-      ensure
-        yield job if block_given?
-      end
-    end
   end
 end
-
-# stores a record of the job processing sequence.
-# you may wish to reset this in the test `setup` method.
-$SEQUENCE = []
 
 # test job, tracks sequence.
 class SequenceJob
   @queue = :jobs
   def self.perform(i)
-    $SEQUENCE << "work_#{i}".to_sym
+    $SEQ_WRITER.print "work_#{i}\n"
     sleep(2)
   end
 end
@@ -64,20 +40,20 @@ end
 class QuickSequenceJob
   @queue = :jobs
   def self.perform(i)
-    $SEQUENCE << "work_#{i}".to_sym
+    $SEQ_WRITER.print "work_#{i}\n"
   end
 end
 
 
 # test hooks, tracks sequence.
 Resque.after_fork do
-  $SEQUENCE << :after_fork
+  $SEQ_WRITER.print "after_fork\n"
 end
 
 Resque.before_fork do
-  $SEQUENCE << :before_fork
+  $SEQ_WRITER.print "before_fork\n"
 end
 
 Resque.before_child_exit do |worker|
-  $SEQUENCE << "before_child_exit_#{worker.jobs_processed}".to_sym
+  $SEQ_WRITER.print "before_child_exit_#{worker.jobs_processed}\n"
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,8 +12,8 @@ require 'resque-multi-job-forks'
 require 'timeout'
 
 # setup redis & resque.
-redis = Redis.new(:db => 1)
-Resque.redis = redis
+$redis = Redis.new(:db => 1)
+Resque.redis = $redis
 
 # adds simple STDOUT logging to test workers.
 # set `VERBOSE=true` when running the tests to view resques log output.

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -20,10 +20,20 @@ Resque.redis = $redis
 module Resque
   class Worker
 
-    def log(msg)
-      puts "*** #{msg}" unless ENV['VERBOSE'].nil?
+    def log_with_severity(severity, msg)
+      if ENV['VERBOSE']
+        s = severity.to_s[0].upcase
+        $stderr.print "*** [#{Time.now}] [#{Process.pid}] #{self} #{s}: #{msg}\n"
+      end
     end
-    alias_method :log!, :log
+
+    def log(message)
+      log_with_severity :info, message
+    end
+
+    def log!(message)
+      log_with_severity :debug, message
+    end
 
   end
 end

--- a/test/test_resque-multi-job-forks.rb
+++ b/test/test_resque-multi-job-forks.rb
@@ -129,6 +129,7 @@ class TestResqueMultiJobForks < Test::Unit::TestCase
   def teardown
     # make sure we don't clobber any other tests.
     ENV['JOBS_PER_FORK'] = nil
+    Resque::Worker.kill_all_heartbeat_threads
   end
 
 end

--- a/test/test_resque-multi-job-forks.rb
+++ b/test/test_resque-multi-job-forks.rb
@@ -27,6 +27,68 @@ class TestResqueMultiJobForks < Test::Unit::TestCase
                   :before_child_exit_1], sequence, 'correct sequence')
   end
 
+  def test_graceful_shutdown_during_first_job
+    # enough time for all jobs to process.
+    @worker.seconds_per_fork = 60
+
+    Resque.enqueue(SequenceJob, 1)
+    Resque.enqueue(SequenceJob, 2)
+    Thread.new do
+      sleep 1 # before first job can complete
+      @worker.shutdown
+    end
+    # INTERVAL=0 will exit when no more jobs left
+    @worker.work(0)
+    $SEQ_WRITER.close
+    sequence = $SEQ_READER.each_line.map {|l| l.strip.to_sym }
+
+    # test the sequence is correct.
+    assert_equal([:before_fork, :after_fork, :work_1,
+                  :before_child_exit_1], sequence, 'correct sequence')
+  end
+
+  def test_immediate_shutdown_during_first_job
+    # enough time for all jobs to process.
+    @worker.seconds_per_fork = 60
+    @worker.term_child = false
+
+    Resque.enqueue(SequenceJob, 1)
+    Resque.enqueue(SequenceJob, 2)
+    Thread.new do
+      sleep 0.5 # before first job can complete
+      @worker.shutdown!
+    end
+    # INTERVAL=0 will exit when no more jobs left
+    @worker.work(0)
+    $SEQ_WRITER.close
+    sequence = $SEQ_READER.each_line.map {|l| l.strip.to_sym }
+
+    # test the sequence is correct.
+    assert_equal([:before_fork, :after_fork], sequence, 'correct sequence')
+  end
+
+  def test_sigterm_shutdown_during_first_job
+    # enough time for all jobs to process.
+    @worker.seconds_per_fork = 60
+    @worker.term_child = true
+    @worker.term_timeout = 0.5
+
+    Resque.enqueue(SequenceJob, 1)
+    Resque.enqueue(SequenceJob, 2)
+    Thread.new do
+      sleep 0.5 # before first job can complete
+      @worker.shutdown!
+    end
+    # INTERVAL=0 will exit when no more jobs left
+    @worker.work(0)
+    $SEQ_WRITER.close
+    sequence = $SEQ_READER.each_line.map {|l| l.strip.to_sym }
+
+    # test the sequence is correct.
+    assert_equal([:before_fork, :after_fork,
+                  :before_child_exit_1], sequence, 'correct sequence')
+  end
+
   # test we can also limit fork job process by a job limit.
   def test_job_limit_sequence_of_events
     # only allow 20 jobs per fork

--- a/test/test_resque-multi-job-forks.rb
+++ b/test/test_resque-multi-job-forks.rb
@@ -3,7 +3,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), '/helper')
 class TestResqueMultiJobForks < Test::Unit::TestCase
   def setup
     $SEQUENCE = []
-    Resque.redis.flushdb
+    $redis.flushdb
     @worker = Resque::Worker.new(:jobs)
   end
 

--- a/test/test_resque-multi-job-forks.rb
+++ b/test/test_resque-multi-job-forks.rb
@@ -8,6 +8,7 @@ class TestResqueMultiJobForks < Test::Unit::TestCase
   end
 
   def test_timeout_limit_sequence_of_events
+    @worker.log! "in test_timeout_limit_sequence_of_events"
     # only allow enough time for 3 jobs to process.
     @worker.seconds_per_fork = 3
 
@@ -28,6 +29,7 @@ class TestResqueMultiJobForks < Test::Unit::TestCase
   end
 
   def test_graceful_shutdown_during_first_job
+    @worker.log! "in test_graceful_shutdown_during_first_job"
     # enough time for all jobs to process.
     @worker.seconds_per_fork = 60
 
@@ -49,6 +51,7 @@ class TestResqueMultiJobForks < Test::Unit::TestCase
   end
 
   def test_immediate_shutdown_during_first_job
+    @worker.log! "in test_immediate_shutdown_during_first_job"
     # enough time for all jobs to process.
     @worker.seconds_per_fork = 60
     @worker.term_child = false
@@ -70,6 +73,7 @@ class TestResqueMultiJobForks < Test::Unit::TestCase
   end
 
   def test_sigterm_shutdown_during_first_job
+    @worker.log! "in test_sigterm_shutdown_during_first_job"
     # enough time for all jobs to process.
     @worker.seconds_per_fork = 60
     @worker.term_child = true
@@ -94,6 +98,7 @@ class TestResqueMultiJobForks < Test::Unit::TestCase
 
   # test we can also limit fork job process by a job limit.
   def test_job_limit_sequence_of_events
+    @worker.log! "in test_job_limit_sequence_of_events"
     # only allow 20 jobs per fork
     ENV['JOBS_PER_FORK'] = '20'
 
@@ -105,18 +110,25 @@ class TestResqueMultiJobForks < Test::Unit::TestCase
     $SEQ_WRITER.close
     sequence = $SEQ_READER.each_line.map {|l| l.strip.to_sym }
 
-    assert_equal :before_fork,          sequence[0],  'first before_fork call.'
-    assert_equal :after_fork,           sequence[1],  'first after_fork call.'
-    assert_equal :work_20,              sequence[21], '20th chunk of work.'
-    assert_equal :before_child_exit_20, sequence[22], 'first before_child_exit call.'
-    assert_equal :before_fork,          sequence[23], 'final before_fork call.'
-    assert_equal :after_fork,           sequence[24], 'final after_fork call.'
-    assert_equal :work_40,              sequence[44], '40th chunk of work.'
-    assert_equal :before_child_exit_20, sequence[45], 'final before_child_exit call.'
+    assert_equal(%i[
+      before_fork after_fork
+      work_1 work_2 work_3 work_4 work_5
+      work_6 work_7 work_8 work_9 work_10
+      work_11 work_12 work_13 work_14 work_15
+      work_16 work_17 work_18 work_19 work_20
+      before_child_exit_20
+      before_fork after_fork
+      work_21 work_22 work_23 work_24 work_25
+      work_26 work_27 work_28 work_29 work_30
+      work_31 work_32 work_33 work_34 work_35
+      work_36 work_37 work_38 work_39 work_40
+      before_child_exit_20
+    ], sequence, 'correct sequence')
   end
 
   def teardown
     # make sure we don't clobber any other tests.
     ENV['JOBS_PER_FORK'] = nil
   end
+
 end

--- a/test/test_rss_reader.rb
+++ b/test/test_rss_reader.rb
@@ -7,17 +7,20 @@ class TestRssReader < Test::Unit::TestCase
     @object.extend Resque::Plugins::MultiJobForks::RssReader
   end
 
+  # support before/after ruby 2.4 without deprecation notice
+  IntegerClass = 1.class
+
   def test_current_process_rss
     rss = @object.rss
     # not a very strict test, but have you ever seen a ruby process < 1Mb?
     # the "real" test is manual verification via top/ps/htop
-    assert_equal Fixnum, rss.class
+    assert_equal IntegerClass, rss.class
     assert @object.rss > 1000
   end
 
   def test_rss_other_processes
     rss = @object.rss(1) # init is guaranteed to exist
-    assert_equal Fixnum, rss.class
+    assert_equal IntegerClass, rss.class
     assert @object.rss > 1000
   end
 


### PR DESCRIPTION
n.b. the changes for 1.27.x (in #14) also worked for 2.0.0. So this does no more than update the gemspec to allow `>= 1.27.0, < 2.1`

compare for just this: https://github.com/nevans/resque-multi-job-forks/compare/fix-resque-v1.27...fix-resque-v2.0