### PR TITLE
Allow `before_child_exit` block to be optional

### DIFF
--- a/lib/resque-multi-job-forks.rb
+++ b/lib/resque-multi-job-forks.rb
@@ -169,16 +169,11 @@ module Resque
   # Call with a block to set the hook.
   # Call with no arguments to return the hook.
   def self.before_child_exit(&block)
-    if block
-      @before_child_exit ||= []
-      @before_child_exit << block
-    end
-    @before_child_exit
+    block ? register_hook(:before_child_exit, block) : hooks(:before_child_exit)
   end
 
   # Set the before_child_exit proc.
   def self.before_child_exit=(before_child_exit)
-    @before_child_exit = before_child_exit.respond_to?(:each) ? before_child_exit : [before_child_exit].compact
+    register_hook(:before_child_exit, block)
   end
-
 end


### PR DESCRIPTION
Rather than re-implement hook registration, lean on the existing methods
in Resque.

For example, here is how the `after_fork` hook is registered: https://github.com/resque/resque/blob/85706d536287910c53e0eb14e98c612b03dbea20/lib/resque.rb#L259

This fixes a bug where resque will error if a `before_child_exit` hook
has not been registered (https://github.com/stulentsev/resque-multi-job-forks/issues/19).