### PR TITLE
Use `log_with_severity` over deprecated `log`/`log!`

### DIFF
--- a/lib/resque-multi-job-forks.rb
+++ b/lib/resque-multi-job-forks.rb
@@ -91,7 +91,7 @@ module Resque
     def shutdown_child
       return unless @child
       begin
-        log! "multi_jobs_per_fork: Sending QUIT signal to #{@child}"
+        log_with_severity :debug, "multi_jobs_per_fork: Sending QUIT signal to #{@child}"
         Process.kill('QUIT', @child)
       rescue Errno::ESRCH
         nil
@@ -112,7 +112,7 @@ module Resque
     end
 
     def hijack_fork
-      log 'hijack fork.'
+      log_with_severity :debug, 'hijack fork.'
       @suppressed_fork_hooks = [Resque.after_fork, Resque.before_fork]
       Resque.after_fork = Resque.before_fork = nil
       @release_fork_limit = fork_job_limit
@@ -121,11 +121,11 @@ module Resque
     end
 
     def release_fork
-      log "jobs processed by child: #{jobs_processed}; rss: #{rss}"
+      log_with_severity :info, "jobs processed by child: #{jobs_processed}; rss: #{rss}"
       run_hook :before_child_exit, self
       Resque.after_fork, Resque.before_fork = *@suppressed_fork_hooks
       @release_fork_limit = @jobs_processed = nil
-      log 'hijack over, counter terrorists win.'
+      log_with_severity :debug, 'hijack over, counter terrorists win.'
       @shutdown = true
     end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -27,14 +27,6 @@ module Resque
       end
     end
 
-    def log(message)
-      log_with_severity :info, message
-    end
-
-    def log!(message)
-      log_with_severity :debug, message
-    end
-
   end
 end
 

--- a/test/test_resque-multi-job-forks.rb
+++ b/test/test_resque-multi-job-forks.rb
@@ -8,7 +8,7 @@ class TestResqueMultiJobForks < Test::Unit::TestCase
   end
 
   def test_timeout_limit_sequence_of_events
-    @worker.log! "in test_timeout_limit_sequence_of_events"
+    @worker.log_with_severity :debug, "in test_timeout_limit_sequence_of_events"
     # only allow enough time for 3 jobs to process.
     @worker.seconds_per_fork = 3
 
@@ -29,7 +29,7 @@ class TestResqueMultiJobForks < Test::Unit::TestCase
   end
 
   def test_graceful_shutdown_during_first_job
-    @worker.log! "in test_graceful_shutdown_during_first_job"
+    @worker.log_with_severity :debug, "in test_graceful_shutdown_during_first_job"
     # enough time for all jobs to process.
     @worker.seconds_per_fork = 60
 
@@ -51,7 +51,7 @@ class TestResqueMultiJobForks < Test::Unit::TestCase
   end
 
   def test_immediate_shutdown_during_first_job
-    @worker.log! "in test_immediate_shutdown_during_first_job"
+    @worker.log_with_severity :debug, "in test_immediate_shutdown_during_first_job"
     # enough time for all jobs to process.
     @worker.seconds_per_fork = 60
     @worker.term_child = false
@@ -73,7 +73,7 @@ class TestResqueMultiJobForks < Test::Unit::TestCase
   end
 
   def test_sigterm_shutdown_during_first_job
-    @worker.log! "in test_sigterm_shutdown_during_first_job"
+    @worker.log_with_severity :debug, "in test_sigterm_shutdown_during_first_job"
     # enough time for all jobs to process.
     @worker.seconds_per_fork = 60
     @worker.term_child = true
@@ -98,7 +98,7 @@ class TestResqueMultiJobForks < Test::Unit::TestCase
 
   # test we can also limit fork job process by a job limit.
   def test_job_limit_sequence_of_events
-    @worker.log! "in test_job_limit_sequence_of_events"
+    @worker.log_with_severity :debug, "in test_job_limit_sequence_of_events"
     # only allow 20 jobs per fork
     ENV['JOBS_PER_FORK'] = '20'
 


### PR DESCRIPTION
The Resque gem stopped using the `log` and `log!` methods internally in the `Resque::Worker` class a while ago, and [replaced them with calls to the `log_with_severity` method](https://github.com/resque/resque/pull/1405).

Although the `log` and `log!` methods still exist for backwards compatibility, this change switches to using the more recent `log_with_severity` interface to stay consistent with Resque's internal style.

The `log_with_severity` method was introduced with resque v1.26.0, which is within the `>= 1.27.0", "< 2.1"` compatibility range listed in the [resque-multi-job-forks.gemspec](https://github.com/stulentsev/resque-multi-job-forks/blob/ae44c4a260b6ace0e5ab1d9c0422c05bb21033cb/resque-multi-job-forks.gemspec#L14).