### PR TITLE
Relax resque version constraint to include 2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    resque-multi-job-forks (0.5.3)
+    resque-multi-job-forks (0.5.5)
       json
-      resque (>= 1.27.0, < 2.2)
+      resque (>= 1.27.0, < 2.3)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    json (2.5.1)
+    json (2.6.1)
     mono_logger (1.1.1)
     multi_json (1.15.0)
     mustermann (1.1.1)
@@ -18,10 +18,10 @@ GEM
     rack-protection (2.1.0)
       rack
     rake (12.3.2)
-    redis (4.4.0)
+    redis (4.5.1)
     redis-namespace (1.8.1)
       redis (>= 3.0.4)
-    resque (2.1.0)
+    resque (2.2.0)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
       redis-namespace (~> 1.6)

--- a/resque-multi-job-forks.gemspec
+++ b/resque-multi-job-forks.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description = "When your resque jobs are frequent and fast, the overhead of forking and running your after_fork might get too big."
 
   # Depends on minor version, due to monkeypatches Resque::Worker internals.
-  s.add_runtime_dependency("resque", ">= 1.27.0", "< 2.2")
+  s.add_runtime_dependency("resque", ">= 1.27.0", "< 2.3")
   s.add_runtime_dependency("json")
 
   s.add_development_dependency("test-unit")

--- a/resque-multi-job-forks.gemspec
+++ b/resque-multi-job-forks.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "resque-multi-job-forks"
-  s.version     = "0.5.4"
+  s.version     = "0.5.5"
   s.authors     = ["Mick Staugaard", "Luke Antins", 'Sergio Tulentsev']
   s.email       = ["mick@zendesk.com", "luke@lividpenguin.com", 'sergei.tulentsev@gmail.com']
   s.homepage    = "https://github.com/stulentsev/resque-multi-job-forks"


### PR DESCRIPTION
Hey,

resque v2.2 was released in November. I had a brief look at the [changes](https://github.com/resque/resque/compare/2.1.0...v2.2.0) and tested `resque-multi-job-forks` with the new resque version locally.

![image](https://user-images.githubusercontent.com/931787/149182537-2b8862f3-ba26-4ea8-a07c-1126cf51b4d8.png)
![image](https://user-images.githubusercontent.com/931787/149182577-3e81627f-63a8-4079-be7c-50953815607c.png)

Everything looks good to me to also include resque 2.2 in the version constraint. If there is anything left you want me to test, I'm happy to assist.

Cheers