### PR TITLE
Relax version constraint to include Resque version 2.5

### DIFF
--- a/resque-multi-job-forks.gemspec
+++ b/resque-multi-job-forks.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description = "When your resque jobs are frequent and fast, the overhead of forking and running your after_fork might get too big."
 
   # Depends on minor version, due to monkeypatches Resque::Worker internals.
-  s.add_runtime_dependency("resque", ">= 1.27.0", "< 2.5")
+  s.add_runtime_dependency("resque", ">= 1.27.0", "< 2.6")
   s.add_runtime_dependency("json")
 
   s.add_development_dependency("test-unit")


### PR DESCRIPTION
Hey,

resque v2.5 was released a month ago. I had a brief look at the [changes](https://github.com/resque/resque/compare/v2.4.0...v2.5.0) and tested resque-multi-job-forks with the new resque version locally.

<img width="747" alt="image" src="https://user-images.githubusercontent.com/931787/229571891-6732761e-c603-4ff2-b354-f32c2d28b2e8.png">

Everything looks good to me to also include resque 2.5 in the version constraint. If there is anything left you want me to test, I'm happy to assist.

Cheers